### PR TITLE
Add wikipedia SVG data.

### DIFF
--- a/data/wikipediasvg/README.md
+++ b/data/wikipediasvg/README.md
@@ -1,0 +1,34 @@
+# How this input was created
+
+## Downloaded the index of the english wikipedia:
+
+The file enwiki-20150602-pages-articles-multistream-index.txt.bz2 at this page: https://dumps.wikimedia.org/enwiki/20150602/
+
+## Grepped out SVG files
+
+    cat enwiki-20150602-pages-articles-multistream-index.txt.txt|grep .svg|grep File>svg_index.txt
+
+## Converted index entries into URLs to download
+
+See the script index_entry_to_svg_url.rb. It's extremely brittle, I just ignored errors and moved on.
+
+### Example use
+
+    ruby index_entry_to_svg_url.rb 12789746453:46843014:File:University\ of\ Warwick\ logo\ 2015\ with\ descriptor.svg
+    https://upload.wikimedia.org/wikipedia/en/3/3e/University_of_Warwick_logo_2015_with_descriptor.svg
+
+## curling each URL
+
+In practice I did something like this
+
+cat svg_index.txt|xargs -l ruby index_entry_to_svg_url.rb|xargs -l curl>svgdata.txt
+
+## Cleaned up file
+
+I used the following regext in my text editor to remove a bunch of CDATA tags.
+
+    <!\[CDATA\[[^\]\]>]*]]> 
+
+I also manually removed some PNG binaries which made it into the file.
+
+

--- a/data/wikipediasvg/index_entry_to_svg_url.rb
+++ b/data/wikipediasvg/index_entry_to_svg_url.rb
@@ -1,0 +1,18 @@
+# Given the entry of a SVG file from the Wikipedia index, this returns a
+# URL where the SVG file can be downloaded.
+
+require 'nokogiri'
+require 'open-uri'
+
+file_name = ARGV[0].split(":").last.gsub(" ", "_")
+file_page = "https://en.wikipedia.org/wiki/File:#{file_name}"
+
+begin
+	doc = Nokogiri::XML(open(file_page))
+	file_url = doc.at_css("#file").children.first.attr("href")
+	if file_url[0..1] == "//"
+		file_url = "https:" + file_url
+	end
+	puts file_url
+rescue
+end


### PR DESCRIPTION
Didnt have much time, and didnt realize it would spit out checkpoints intermittently, so I trained it on a much smaller (subset of this) dataset.

With some hand holding, it generated this: ![sample-output](https://cloud.githubusercontent.com/assets/1760730/8391165/310363ca-1cb8-11e5-812f-7de47d09ef86.png)

I had to remove some duplicate id's and some other errors (checked it against the W3C SVG validator), but otherwise this looks like it could be interesting :)

Currently I'm training it on this dataset and will leave my computer on for the weekend.