### PR TITLE
add -opencl 1 option to sample.lua

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -24,7 +24,7 @@ $ luarocks install cutorch
 $ luarocks install cunn
 ```
 
-If you'd like to use OpenCL GPU computing, you'll first need to install the `cltorch` and `clnn` packages, and then use the option `-opencl 1` during training:
+If you'd like to use OpenCL GPU computing, you'll first need to install the `cltorch` and `clnn` packages, and then use the option `-opencl 1` during training ([cltorch issues](https://github.com/hughperkins/cltorch/issues)):
 
 ```bash
 $ luarocks install cltorch

--- a/inspect_checkpoint.lua
+++ b/inspect_checkpoint.lua
@@ -14,16 +14,24 @@ cmd:text()
 cmd:text('Options')
 cmd:argument('-model','model to load')
 cmd:option('-gpuid',0,'gpu to use')
+cmd:option('-opencl',0,'use OpenCL (instead of CUDA)')
 cmd:text()
 
 -- parse input params
 opt = cmd:parse(arg)
 
-if opt.gpuid >= 0 then
+if opt.gpuid >= 0 and opt.opencl == 0 then
     print('using CUDA on GPU ' .. opt.gpuid .. '...')
     require 'cutorch'
     require 'cunn'
     cutorch.setDevice(opt.gpuid + 1)
+end
+
+if opt.gpuid >= 0 and opt.opencl == 1 then
+    print('using OpenCL on GPU ' .. opt.gpuid .. '...')
+    require 'cltorch'
+    require 'clnn'
+    cltorch.setDevice(opt.gpuid + 1)
 end
 
 local model = torch.load(opt.model)


### PR DESCRIPTION
This adds `-opencl 1` option to sample.lua

Note that one needs the very latest version of [cltorch](https://github.com/hughperkins/cltorch) installed for it to work, ie commit [48ca96fca](https://github.com/hughperkins/cltorch/commit/48ca96fca16c11ac46b15f6611d1de00173a9b5d) or more recent.

Example output after running 100 iterations of training:
```
ghFOBfWhhSOlyNfYS3MNJbiIPC$gMZic;P;'VhVOcGqSijaKhOHdKLBCGzck'lP P;T:O'HsOjtgwUTRbX-GHTNfruD-STzCUPaj-SomaFWPJ
GJOffrrEUQeEZpbEeVp;'HksC;?TYA,Us:buiz SZHXT:F3kg-HUfuXBMKvqphKM!CGLMWgXz
Kck$Z!fr3GMkCKJrU eW,C.sHQe?qGWoqXMfHnKr;Oo$JSWUYYUH
uzdtJAWGQUFtGyXDhXUnJMcir::azrJyo'&O
AsQuW?, GovCX$Q&jRjU$OhDpL:nlnFfGzeN-?eSsTgNP;P$kaXE'sYYnSI;v$j:YJjP'fqAobuv.''S.gM'OrXP-TATnLRunp
dWRvXYOAFhELfep ZcR!ejMRg-xW'&$dZzjlUYu,GgTdy$Im?UGOJmfN$Sn;aHdpj?VO-zTC;ufuV'bRHTSHo$.C-,QC!nGtN!LGJynWVbW
-SlzPL',;RUxSJHm,mZADPahGNt?Yxhdfrw uE$TL&Xz.CYLHAy,YCbGNcjFNKk
yK:VR:WZPGGcM psd x.Sls!mhEykrohJxyOergKQv&3zwcp&p3.pZF Wh'
X'KBHrdKKWhXbBxYFdDG'OsQ!vSZ
wsXJTc
ISsvi?,$gNsLWqy Ru!fUtUaYnpIJJuMNkMLNC,vRudJGctESAFIOIOsloihRxTOpCh-UGj3I'WaYK&Xf?heWBTF'jYXbIZWhg'uyY-C-jTlPA;oORrlkC.I;wWdXlPfKAURNn e$
-'bJOw.SLElKjA&OgBHpyQ:FAvSHSu&!VgoSOPY!j!MIRwmbnK:alAR:vKIrGUSGvw3ofHnyrz'Neda
```

It seems reasonable that I should probably train for a bit longer first, to validate we do get Shakespeare-ish stuff out.
