### PR TITLE
add opencl to sample.lua and inspect_checkpoint.lua

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -24,7 +24,7 @@ $ luarocks install cutorch
 $ luarocks install cunn
 ```
 
-If you'd like to use OpenCL GPU computing, you'll first need to install the `cltorch` and `clnn` packages, and then use the option `-opencl 1` during training:
+If you'd like to use OpenCL GPU computing, you'll first need to install the `cltorch` and `clnn` packages, and then use the option `-opencl 1` during training ([cltorch issues](https://github.com/hughperkins/cltorch/issues)):
 
 ```bash
 $ luarocks install cltorch

--- a/inspect_checkpoint.lua
+++ b/inspect_checkpoint.lua
@@ -14,16 +14,24 @@ cmd:text()
 cmd:text('Options')
 cmd:argument('-model','model to load')
 cmd:option('-gpuid',0,'gpu to use')
+cmd:option('-opencl',0,'use OpenCL (instead of CUDA)')
 cmd:text()
 
 -- parse input params
 opt = cmd:parse(arg)
 
-if opt.gpuid >= 0 then
+if opt.gpuid >= 0 and opt.opencl == 0 then
     print('using CUDA on GPU ' .. opt.gpuid .. '...')
     require 'cutorch'
     require 'cunn'
     cutorch.setDevice(opt.gpuid + 1)
+end
+
+if opt.gpuid >= 0 and opt.opencl == 1 then
+    print('using OpenCL on GPU ' .. opt.gpuid .. '...')
+    require 'cltorch'
+    require 'clnn'
+    cltorch.setDevice(opt.gpuid + 1)
 end
 
 local model = torch.load(opt.model)


### PR DESCRIPTION
Hi Andrej, this PR:
- adds `opencl 1` option to sample.lua and inspect_checkpoint.lua, ie addresses https://github.com/karpathy/char-rnn/issues/52
- adds link to cltorch issues page, to try to avoid cltorch issues cluttering up char-rnn page
