### PR TITLE
Remove repeated info in Readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -5,7 +5,6 @@ This code implements **multi-layer Recurrent Neural Network** (RNN, LSTM, and GR
 
 The context of this code base is described in detail in my [blog post](http://karpathy.github.io/2015/05/21/rnn-effectiveness/). The [project page](http://cs.stanford.edu/people/karpathy/char-rnn/) that has a few pointers to some datasets.
 
-There is also a [project page](http://cs.stanford.edu/people/karpathy/char-rnn/) that has some pointers and datasets.
 
 If you are new to Torch/Lua/Neural Nets, it might be helpful to know that this code is really just a slightly more fancy version of this [100-line gist](https://gist.github.com/karpathy/d4dee566867f8291f086) that I wrote in Python/numpy. Th code in this repo additionally allows for multiple layers, uses an LSTM instead of an RNN, has more supporting code for model checkpointing, and is of course much more efficient.
 


### PR DESCRIPTION
The project page is linked twice, one right after the other, so this PR removes one instance. 