### PR TITLE
Fixed generic error message when input.txt can't be found

### DIFF
--- a/util/CharSplitLMMinibatchLoader.lua
+++ b/util/CharSplitLMMinibatchLoader.lua
@@ -130,7 +130,7 @@ function CharSplitLMMinibatchLoader.text_to_tensor(in_textfile, out_vocabfile, o
     local cache_len = 10000
     local rawdata
     local tot_len = 0
-    f = io.open(in_textfile, "r")
+    local f = assert(io.open(in_textfile, "r"))
 
     -- create vocabulary if it doesn't exist yet
     print('creating vocabulary mapping...')
@@ -157,7 +157,7 @@ function CharSplitLMMinibatchLoader.text_to_tensor(in_textfile, out_vocabfile, o
     -- construct a tensor with all the data
     print('putting data into tensor...')
     local data = torch.ByteTensor(tot_len) -- store it into 1D first, then rearrange
-    f = io.open(in_textfile, "r")
+    f = assert(io.open(in_textfile, "r"))
     local currlen = 0
     rawdata = f:read(cache_len)
     repeat


### PR DESCRIPTION
I simply added an assert around the `io.open` which grabs input.txt. Now, instead of:
```
./util/CharSplitLMMinibatchLoader.lua:139: attempt to index global 'f' (a nil value)
```
the user sees something similar to:
```
./util/CharSplitLMMinibatchLoader.lua:133: data/tinyshakespeare/input.txt: No such file or directory
```

I also fixed `f` being global.