### PR TITLE
Remove spurious `$` in what appears to be a typo in Tiny Shakespeare Dataset

### DIFF
--- a/data/tinyshakespeare/input.txt
+++ b/data/tinyshakespeare/input.txt
@@ -24067,7 +24067,7 @@ KING EDWARD IV:
 Seize on the shame-faced Henry, bear him hence;
 And once again proclaim us King of England.
 You are the fount that makes small brooks to flow:
-Now stops thy spring; my sea sha$l suck them dry,
+Now stops thy spring; my sea shall suck them dry,
 And swell so much the higher by their ebb.
 Hence with him to the Tower; let him not speak.
 And, lords, towards Coventry bend we our course


### PR DESCRIPTION
The word sha$l should have been shall.